### PR TITLE
Switch build configuration to pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ or::
     
     git clone https://github.com/hhuangwx/cmaps.git
     cd cmaps
-    python setup.py install
+    pip install .
 
 
 .. image:: examples/colormaps.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cmaps"
+version = "2.0.1"
+description = "Make it easier to use user defined colormaps in matplotlib."
+readme = "README.rst"
+requires-python = ">=3.8"
+authors = [{ name = "Hao Huang", email = "hhuangwx@gmail.com" }]
+license = {file = "LICENSE"}
+dependencies = [
+    "matplotlib",
+    "numpy",
+    "packaging",
+]
+
+[tool.setuptools.package-data]
+cmaps = [
+    "colormaps/ncar_ncl/*",
+    "colormaps/self_defined/*",
+]
+
+[tool.setuptools.data-files]
+"" = ["cmaps.template", "LICENSE"]
+


### PR DESCRIPTION
## Summary
- use modern pyproject.toml with setuptools build backend
- update installation instructions in `README.rst`

## Testing
- `python -m pip install . --no-deps -vv` *(fails: Could not find a matching distribution for setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_6889c8982b1c8323b15e31e21bb89d2f